### PR TITLE
Show all times in eastern time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1244,6 +1244,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc3b69b799a03e059f6dc984c25a8bf847d8ca4cbddb079c39ede7b3d24854c3"
 dependencies = [
  "chrono",
+ "chrono-tz",
  "iso8601",
  "nom",
  "nom-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,6 @@ anyhow = "1"
 futures-util = "0.3"
 dotenvy = "0.15.7" # Environment variable loading
 html-escape = "0.2.13"
-icalendar = "0.17.6"
+icalendar = { version = "0.17.6", features = ["chrono-tz"] }
 uuid = { version = "1.19.0", features = ["v4", "serde"] }
 chrono-tz = "0.10.4"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use base64::{engine::general_purpose::STANDARD as b64, Engine as _};
 use chrono::{DateTime, Utc};
 use chrono_tz::America::New_York;
 use dotenvy::dotenv;
-use icalendar::{Calendar, Component, Event as IcalEvent, EventLike};
+use icalendar::{Calendar, CalendarDateTime, Component, Event as IcalEvent, EventLike};
 use rustls;
 use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Serialize};
@@ -353,12 +353,17 @@ async fn event_ical(state: Data<AppState>, path: web::Path<i64>) -> HttpResponse
             }
 
             if let Some(start) = event.start_date {
-                ical_event.starts(start);
+                let start_et = start.with_timezone(&New_York);
+                ical_event.starts(CalendarDateTime::from_date_time(start_et));
                 if let Some(end) = event.end_date {
-                    ical_event.ends(end);
+                    ical_event.ends(CalendarDateTime::from_date_time(
+                        end.with_timezone(&New_York),
+                    ));
                 } else {
                     // Default to 1 hour duration if no end date
-                    ical_event.ends(start + chrono::Duration::hours(1));
+                    ical_event.ends(CalendarDateTime::from_date_time(
+                        start_et + chrono::Duration::hours(1),
+                    ));
                 }
             }
 


### PR DESCRIPTION
The times were showing up as UTC, which is wrong for the east coast. Let's use eastern by default. In the future if we expand this website outside of the boston area we could do something to detect timezones based on location of event, but I think that's an anti-goal right now.