### PR TITLE
Handle non-event uploads and require event start times

### DIFF
--- a/migrations/20260101000000_require_start_date.sql
+++ b/migrations/20260101000000_require_start_date.sql
@@ -1,0 +1,6 @@
+-- Remove events without a start date; they are not usable.
+DELETE FROM app.events WHERE start_date IS NULL;
+
+-- Enforce start_date presence going forward.
+ALTER TABLE app.events
+    ALTER COLUMN start_date SET NOT NULL;

--- a/src/db.rs
+++ b/src/db.rs
@@ -17,22 +17,21 @@ pub struct EventsDatabase {
 #[async_trait]
 impl EventsRepo for EventsDatabase {
     async fn list(&self) -> Result<Vec<Event>> {
-        let events = sqlx::query_as!(
-            Event,
+        let events = sqlx::query_as::<_, Event>(
             r#"
-            SELECT
-                id,
-                name,
-                full_description,
-                start_date,
-                end_date,
-                location,
-                event_type,
-                additional_details,
-                confidence
-            FROM app.events
-            ORDER BY start_date ASC NULLS LAST
-            "#
+                    SELECT
+                        id,
+                        name,
+                        full_description,
+                        start_date,
+                        end_date,
+                        location,
+                        event_type,
+                        additional_details,
+                        confidence
+                    FROM app.events
+                    ORDER BY start_date ASC
+                "#,
         )
         .fetch_all(&self.pool)
         .await?;
@@ -40,39 +39,38 @@ impl EventsRepo for EventsDatabase {
     }
 
     async fn get(&self, id: i64) -> Result<Option<Event>> {
-        let event = sqlx::query_as!(
-            Event,
+        let event = sqlx::query_as::<_, Event>(
             r#"
-            SELECT
-                id,
-                name,
-                full_description,
-                start_date,
-                end_date,
-                location,
-                event_type,
-                additional_details,
-                confidence
-            FROM app.events
-            WHERE id = $1
-            "#,
-            id
+                    SELECT
+                        id,
+                        name,
+                        full_description,
+                        start_date,
+                        end_date,
+                        location,
+                        event_type,
+                        additional_details,
+                        confidence
+                    FROM app.events
+                    WHERE id = $1
+                "#,
         )
+        .bind(id)
         .fetch_optional(&self.pool)
         .await?;
         Ok(event)
     }
 
     async fn claim_idempotency_key(&self, idempotency_key: uuid::Uuid) -> Result<bool> {
-        let insert_result = sqlx::query!(
+        let insert_result = sqlx::query(
             r#"
-            INSERT INTO app.idempotency_keys (idempotency_key)
-            VALUES ($1)
-            ON CONFLICT DO NOTHING
-            RETURNING idempotency_key
+                INSERT INTO app.idempotency_keys (idempotency_key)
+                VALUES ($1)
+                ON CONFLICT DO NOTHING
+                RETURNING idempotency_key
             "#,
-            idempotency_key
         )
+        .bind(idempotency_key)
         .fetch_optional(&self.pool)
         .await?;
 
@@ -88,7 +86,7 @@ pub async fn save_event_to_db<'e, E>(executor: E, event: &Event) -> Result<i64>
 where
     E: sqlx::PgExecutor<'e>,
 {
-    let id = sqlx::query_scalar!(
+    let id = sqlx::query_scalar(
         r#"
         INSERT INTO app.events (
             name,
@@ -103,15 +101,15 @@ where
         VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
         RETURNING id
         "#,
-        event.name,
-        event.full_description,
-        event.start_date,
-        event.end_date,
-        event.location,
-        event.event_type,
-        event.additional_details.as_deref(),
-        event.confidence
     )
+    .bind(&event.name)
+    .bind(&event.full_description)
+    .bind(event.start_date)
+    .bind(event.end_date)
+    .bind(&event.location)
+    .bind(&event.event_type)
+    .bind(event.additional_details.as_deref())
+    .bind(event.confidence)
     .fetch_one(executor)
     .await
     .map_err(|e| anyhow!("Database insert failed: {e}"))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -353,7 +353,8 @@ mod tests {
             &state.api_key,
             fixed_now_utc,
         )
-        .await?;
+        .await?
+        .expect("expected an event to be parsed");
         assert_eq!(event.name, "Dance Therapy");
 
         // "Database" behavior: verify we can "persist" it via the repo without touching Postgres.
@@ -410,7 +411,7 @@ mod tests {
             id: Some(1),
             name: "Past Event".to_string(),
             full_description: "Should not render".to_string(),
-            start_date: Some(mk_local(local_dt(yesterday_local, 10, 0)).with_timezone(&Utc)),
+            start_date: mk_local(local_dt(yesterday_local, 10, 0)).with_timezone(&Utc),
             end_date: Some(mk_local(local_dt(yesterday_local, 11, 0)).with_timezone(&Utc)),
             location: Some("Somewhere".to_string()),
             event_type: None,
@@ -423,7 +424,7 @@ mod tests {
             id: Some(2),
             name: "Ongoing No End".to_string(),
             full_description: "Should render once".to_string(),
-            start_date: Some(mk_local(local_dt(today_local, 9, 0)).with_timezone(&Utc)),
+            start_date: mk_local(local_dt(today_local, 9, 0)).with_timezone(&Utc),
             end_date: None,
             location: Some("Somerville".to_string()),
             event_type: None,
@@ -437,7 +438,7 @@ mod tests {
             id: Some(7),
             name: "Yesterday No End".to_string(),
             full_description: "Should render under yesterday".to_string(),
-            start_date: Some(mk_local(local_dt(yesterday_local, 15, 0)).with_timezone(&Utc)),
+            start_date: mk_local(local_dt(yesterday_local, 15, 0)).with_timezone(&Utc),
             end_date: None,
             location: Some("Somerville".to_string()),
             event_type: None,
@@ -450,7 +451,7 @@ mod tests {
             id: Some(5),
             name: "Same Day 1".to_string(),
             full_description: "First event on the same day".to_string(),
-            start_date: Some(mk_local(local_dt(today_local, 10, 0)).with_timezone(&Utc)),
+            start_date: mk_local(local_dt(today_local, 10, 0)).with_timezone(&Utc),
             // No end_date so this test doesn't become time-of-day dependent.
             end_date: None,
             location: Some("Union".to_string()),
@@ -463,7 +464,7 @@ mod tests {
             id: Some(6),
             name: "Same Day 2".to_string(),
             full_description: "Second event on the same day".to_string(),
-            start_date: Some(mk_local(local_dt(today_local, 12, 0)).with_timezone(&Utc)),
+            start_date: mk_local(local_dt(today_local, 12, 0)).with_timezone(&Utc),
             // No end_date so this test doesn't become time-of-day dependent.
             end_date: None,
             location: Some("Magoun".to_string()),
@@ -477,22 +478,9 @@ mod tests {
             id: Some(3),
             name: "Multi Day".to_string(),
             full_description: "Spans multiple days".to_string(),
-            start_date: Some(mk_local(local_dt(tomorrow_local, 12, 0)).with_timezone(&Utc)),
+            start_date: mk_local(local_dt(tomorrow_local, 12, 0)).with_timezone(&Utc),
             end_date: Some(mk_local(local_dt(day_after_tomorrow_local, 13, 0)).with_timezone(&Utc)),
             location: Some("Davis".to_string()),
-            event_type: None,
-            additional_details: None,
-            confidence: 1.0,
-        };
-
-        // Missing start: should be excluded entirely.
-        let missing_start = Event {
-            id: Some(4),
-            name: "Missing Start".to_string(),
-            full_description: "Not an event".to_string(),
-            start_date: None,
-            end_date: Some(mk_local(local_dt(tomorrow_local, 10, 0)).with_timezone(&Utc)),
-            location: None,
             event_type: None,
             additional_details: None,
             confidence: 1.0,
@@ -502,7 +490,6 @@ mod tests {
         let fake_repo = FakeEventsRepo {
             events: Arc::new(vec![
                 multi_day,
-                missing_start,
                 past_event,
                 same_day_2,
                 ongoing_no_end,

--- a/src/models.rs
+++ b/src/models.rs
@@ -9,7 +9,7 @@ pub struct Event {
     /// The full description of the event or content
     pub full_description: String,
     /// The date and time of the event
-    pub start_date: Option<DateTime<Utc>>,
+    pub start_date: DateTime<Utc>,
     /// The end date of the event
     pub end_date: Option<DateTime<Utc>>,
     /// The location of the event
@@ -24,4 +24,13 @@ pub struct Event {
     #[serde(skip, default)]
     #[schemars(skip)]
     pub id: Option<i64>,
+}
+
+/// Wrapper for LLM extraction so we can distinguish "no event found" from a valid event.
+#[derive(Debug, Serialize, Deserialize, JsonSchema, PartialEq, Clone)]
+pub struct EventExtraction {
+    /// The extracted event. Use `null` when the image is not an event or lacks a usable date.
+    pub event: Option<Event>,
+    /// Optional explanation when no event is returned.
+    pub reason: Option<String>,
 }


### PR DESCRIPTION
## Summary
- require event start times in the schema and database, cleaning out null start dates during migration
- update the upload pipeline and LLM schema to return `event: null` for non-events or missing dates instead of inserting placeholders
- adjust event rendering and database access to reflect the mandatory start time and runtime-checked queries

## Testing
- cargo test test_index


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694887a8185483299cb4cba63ec3ed45)