### PR TITLE
Handle multi-event posters

### DIFF
--- a/src/features/upload/mod.rs
+++ b/src/features/upload/mod.rs
@@ -92,21 +92,13 @@ pub async fn save(
     let dest_path_clone = dest_path.clone();
 
     actix_web::rt::spawn(async move {
-        match parse_image(
-            &dest_path_clone,
-            state.client.clone(),
-            &state.openai_api_key,
-        )
-        .await
-        {
+        match parse_image(&dest_path_clone, &state.client, &state.openai_api_key).await {
             Ok(mut events) => {
                 if events.is_empty() {
                     log::info!("Image processed but no events found");
                 } else {
-                    let client = state.client.clone();
-                    let key = state.google_maps_api_key.clone();
-
-                    hydrate_event_locations(&mut events, &client, &key).await;
+                    hydrate_event_locations(&mut events, &state.client, &state.google_maps_api_key)
+                        .await;
 
                     for event in &mut events {
                         match state.events_repo.insert(event).await {

--- a/src/image_processing.rs
+++ b/src/image_processing.rs
@@ -41,14 +41,14 @@ pub struct ImageEventExtraction {
     pub events: Vec<SingleEventExtraction>,
 }
 
-pub async fn parse_image(image_path: &Path, client: Client, api_key: &str) -> Result<Vec<Event>> {
+pub async fn parse_image(image_path: &Path, client: &Client, api_key: &str) -> Result<Vec<Event>> {
     parse_image_with_now(image_path, Utc::now(), client, api_key).await
 }
 
 async fn parse_image_with_now(
     image_path: &Path,
     now: DateTime<Utc>,
-    client: Client,
+    client: &Client,
     api_key: &str,
 ) -> Result<Vec<Event>> {
     let path = image_path.to_path_buf();
@@ -301,7 +301,7 @@ mod tests {
         let events = parse_image_with_now(
             Path::new("examples/dance_flyer.jpg"),
             fixed_now_utc,
-            client,
+            &client,
             &config.openai_api_key,
         )
         .await?;
@@ -336,7 +336,7 @@ mod tests {
         let events = parse_image_with_now(
             Path::new("examples/selfie.jpg"),
             fixed_now_utc,
-            client,
+            &client,
             &config.openai_api_key,
         )
         .await?;
@@ -361,7 +361,7 @@ mod tests {
         let events = parse_image_with_now(
             Path::new("examples/soda_ad.jpg"),
             fixed_now_utc,
-            client,
+            &client,
             &config.openai_api_key,
         )
         .await?;
@@ -385,7 +385,7 @@ mod tests {
         let events = parse_image_with_now(
             Path::new("examples/pumpkin_smash.jpeg"),
             fixed_now_utc,
-            client,
+            &client,
             &config.openai_api_key,
         )
         .await?;
@@ -438,7 +438,7 @@ mod tests {
         let events = parse_image_with_now(
             Path::new("examples/dsnc_flyer.png"),
             fixed_now_utc,
-            client,
+            &client,
             &config.openai_api_key,
         )
         .await?;


### PR DESCRIPTION
Some flyers have multiple events on them instead of one event. For instance this flyer has three separate datetimes:

<img width="740" height="917" alt="dsnc_flyer" src="https://github.com/user-attachments/assets/f94a769a-a059-4881-9113-10e5706d7a1d" />


Previously those flyers were incorrectly getting parsed into one long multi-day that had a start date of the first date on the flyer, and an end-date on the last date of the flyer, ignoring all the in-between dates.

Now they correctly parse into multiple events in the database.