### PR TITLE
Set HTML content type for upload success response

### DIFF
--- a/src/features/upload/mod.rs
+++ b/src/features/upload/mod.rs
@@ -138,7 +138,9 @@ pub async fn save(
 
 pub async fn success() -> impl Responder {
     let template = SuccessTemplate;
-    HttpResponse::Ok().body(template.render().unwrap())
+    HttpResponse::Ok()
+        .content_type(ContentType::html())
+        .body(template.render().unwrap())
 }
 
 pub async fn hydrate_event_locations(


### PR DESCRIPTION
### Motivation
- The upload success endpoint was returning HTML markup without an explicit MIME type, causing browsers to treat it as plain text.
- Other HTML-rendering endpoints already set `Content-Type: text/html`, so this brings behavior into alignment.

### Description
- Added `content_type(ContentType::html())` to the `success()` handler response in `src/features/upload/mod.rs`.
- The `success()` handler now returns `HttpResponse::Ok().content_type(ContentType::html()).body(...)` so the Askama template is served as HTML.

### Testing
- No automated tests were executed as part of this change.
- Manual verification is recommended to confirm browsers now render the upload success page as HTML.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e9171df88329b7a0ed781b4bf4f5)