### PR TITLE
Serve calendar invites inline for Android

### DIFF
--- a/src/features/view/mod.rs
+++ b/src/features/view/mod.rs
@@ -245,7 +245,7 @@ pub async fn ical(state: web::Data<AppState>, path: web::Path<i64>) -> impl Resp
                 .content_type("text/calendar")
                 .insert_header((
                     "Content-Disposition",
-                    format!("attachment; filename=\"event-{}.ics\"", id),
+                    format!("inline; filename=\"event-{}.ics\"", id),
                 ))
                 .body(calendar.to_string())
         }


### PR DESCRIPTION
### Motivation

- Android devices were downloading the `.ics` file instead of opening the calendar app when users clicked "Add to calendar".
- Serving the calendar invite inline prompts Android to open the user’s calendar with the event ready to add while continuing to work on iOS.

### Description

- Change the `ical` handler in `src/features/view/mod.rs` to set the `Content-Disposition` header to `inline` instead of `attachment`.
- The response still uses `Content-Type: text/calendar` and returns the generated iCalendar body unchanged.
- This is a single-line behavioral change: `format!("attachment; filename=...")` -> `format!("inline; filename=...")`.

### Testing

- No automated tests were executed as part of this change.
- The repository contains an existing test `test_ical_endpoint` that verifies the iCal response content, but it was not run here.
- Manual verification is recommended on Android and iOS to confirm the calendar app opens and the event details appear correctly.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952eb7000bc8329af3953e781289f12)