### PR TITLE
Move upload button above image preview

### DIFF
--- a/src/features/upload/upload.html
+++ b/src/features/upload/upload.html
@@ -189,9 +189,8 @@
     
     <input type="file" name="image" accept="image/*" required>
 
-    <img alt="Selected Image Preview">
-
     <button type="submit">Upload</button>
+
+    <img alt="Selected Image Preview">
 </form>
 {% endblock %}
-


### PR DESCRIPTION
### Motivation
- Prevent the upload button from being pushed below the fold on mobile by placing it above the image preview. 
- Improve usability for users who select files on small screens where the preview can push controls off-screen.

### Description
- Reordered form elements in `src/features/upload/upload.html` so the `<button type="submit">Upload</button>` appears before the `<img alt="Selected Image Preview">` element.
- This is a markup-only change with no backend or JS logic updates.

### Testing
- Attempted to run a smoke test with `cargo run`, but the application failed to start due to missing environment configuration.
- `cargo run` failed with a panic: `HOST must be set` (no further automated tests were executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952ead91e8483298c27f67a3f144a67)